### PR TITLE
Set upper version of knime core dependency to 5.0.0

### DIFF
--- a/de.mpicbg.knime.ip.clearvolume.base/META-INF/MANIFEST.MF
+++ b/de.mpicbg.knime.ip.clearvolume.base/META-INF/MANIFEST.MF
@@ -71,6 +71,6 @@ Require-Bundle: scijava-common;bundle-version="2.62.1",
  org.knime.knip.core;bundle-version="[1.3.0,2.0.0)",
  org.knime.knip.cellviewer;bundle-version="[1.3.0,2.0.0)",
  org.knime.knip.base;bundle-version="[1.3.0,2.0.0)",
- org.knime.core;bundle-version="[3.0.0,4.0.0)",
+ org.knime.core;bundle-version="[3.0.0,5.0.0)",
  org.junit;bundle-version="4.12.0",
  org.slf4j.api;bundle-version="1.7.2"


### PR DESCRIPTION
The major version of KNIME Analytics Platform is changing with the next release, without this change users will no longer be able to install the extension.
